### PR TITLE
Added the validator integration

### DIFF
--- a/Resources/config/odm.xml
+++ b/Resources/config/odm.xml
@@ -29,18 +29,22 @@
         <parameter key="doctrine_couchdb.odm.metadata.xml.class">Doctrine\Bundle\CouchDBBundle\Mapping\Driver\XmlDriver</parameter>
         <parameter key="doctrine_couchdb.odm.metadata.yml.class">Doctrine\Bundle\CouchDBBundle\Mapping\Driver\YamlDriver</parameter>
         <parameter key="doctrine_couchdb.odm.metadata.php.class">Doctrine\ODM\CouchDB\Mapping\Driver\PHPDriver</parameter>
+
+        <!-- validator -->
+        <parameter key="doctrine_couchdb.odm.validator.unique.class">Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator</parameter>
+        <parameter key="doctrine_couchdb.odm.validator_initializer.class">Symfony\Bridge\Doctrine\Validator\DoctrineInitializer</parameter>
     </parameters>
 
     <services>
         <service id="doctrine_couchdb.odm.metadata.annotation_reader" class="%doctrine_couchdb.odm.metadata.annotation_reader.class%" public="false">
             <argument type="service" id="annotation_reader" />
         </service>
-        
+
         <service id="doctrine_couchdb.odm.proxy_cache_warmer" class="%doctrine_couchdb.odm.proxy_cache_warmer.class%" public="false">
             <tag name="kernel.cache_warmer" />
             <argument type="service" id="service_container" />
         </service>
-        
+
         <service
             id="doctrine_couchdb.odm.configuration"
             class="%doctrine_couchdb.odm.configuration.class%"
@@ -64,6 +68,17 @@
 
         <service id="form.type_guesser.doctrine_couchdb" class="%form.type_guesser.doctrine_couchdb.class%">
             <tag name="form.type_guesser" />
+            <argument type="service" id="doctrine_couchdb" />
+        </service>
+
+        <!-- validator -->
+        <service id="doctrine_couchdb.odm.validator.unique" class="%doctrine_couchdb.odm.validator.unique.class%">
+            <tag name="validator.constraint_validator" alias="doctrine_couchdb.odm.validator.unique" />
+            <argument type="service" id="doctrine_couchdb" />
+        </service>
+
+        <service id="doctrine_couchdb.odm.validator_initializer" class="%doctrine_couchdb.odm.validator_initializer.class%">
+            <tag name="validator.initializer" />
             <argument type="service" id="doctrine_couchdb" />
         </service>
 

--- a/Validator/Constraints/UniqueEntity.php
+++ b/Validator/Constraints/UniqueEntity.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Doctrine CouchDBBundle
+ *
+ * (c) Doctrine Project, Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\CouchDBBundle\Validator\Constraints;
+
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity as BaseConstraint;
+
+/**
+ * Constraint for the Unique Entity validator
+ *
+ * @Annotation
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
+class UniqueEntity extends BaseConstraint
+{
+    public $service = 'doctrine_couchdb.odm.validator.unique';
+}


### PR DESCRIPTION
This registers the validator initializer for CouchDB to allow validating proxies without issue and the unique validator. The constraint is added for convenience to avoid people to add the validator id in their validation mapping.
