### PR TITLE
Fix access level violation

### DIFF
--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -17,17 +17,22 @@ namespace Doctrine\Bundle\CouchDBBundle\Form\Type;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\Form\Exception\FormException;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
 
 class DocumentType extends DoctrineType
 {
     /**
-     * Return the loader object.
+     * CouchDB does not support the queryBuilder, will throw a FormException upon invocation
      *
      * @param ObjectManager $manager
-     * @param array $options
+     * @param mixed         $queryBuilder
+     * @param string        $class
+     *
      * @return EntityLoaderInterface
+     *
+     * @throws FormException
      */
-    protected function getLoader(ObjectManager $manager, array $options)
+    public function getLoader(ObjectManager $manager, $queryBuilder, $class)
     {
         throw new FormException('The query builder option is not supported by CouchDB.');
     }


### PR DESCRIPTION
The getLoader interface has changed and this causes immediate breakage (even upon something simple like php app/console).

I've updated it here, fixed up the doc comment (now correctly indicates that this will immediately throw an exception).
