### PR TITLE
Missing default value of document manager

### DIFF
--- a/Command/UpdateDesignDocCommand.php
+++ b/Command/UpdateDesignDocCommand.php
@@ -17,7 +17,7 @@ class UpdateDesignDocCommand extends DoctrineUpdateDesignDocCommand
 
         $this
             ->setName('doctrine:couchdb:update-design-doc')
-            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command');
+            ->addOption('dm', null, InputOption::VALUE_OPTIONAL, 'The document manager to use for this command', 'default');
     }
     
     protected function execute(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
There is a problem during updating designs.
When I run:

php app/console doctrine:couchdb:update-design-doc Publication  -vvv

it throws:

You have requested a non-existent service "doctrine_couchdb.odm._document_manager".