### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
         "php": ">=5.3.2",
         "doctrine/couchdb-odm": "@dev",
         "doctrine/couchdb": "@dev",
-        "symfony/doctrine-bridge": "~2.0",
-        "symfony/framework-bundle": "~2.0"
+        "symfony/doctrine-bridge": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0"
     },
     "require-dev": {
     },


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0