### PR TITLE
[WIP] Add couchdb entity loader

### DIFF
--- a/Form/ChoiceList/CouchDBEntityLoader.php
+++ b/Form/ChoiceList/CouchDBEntityLoader.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Doctrine\Bundle\CouchDBBundle\Form\ChoiceList;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\CouchDB\DocumentRepository;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityLoaderInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * @author Daniel Espendiller <daniel@espendiller.net>
+ */
+class CouchDBEntityLoader implements EntityLoaderInterface
+{
+
+    /**
+     * @var string
+     */
+    private $class;
+
+    /**
+     * @var ObjectManager
+     */
+    private $dm;
+
+    public function __construct(ObjectManager $dm, $class)
+    {
+        $this->dm = $dm;
+        $this->class = $class;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEntities()
+    {
+        return $this->dm->getRepository($this->class)->findAll();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getEntitiesByIds($identifier, array $values)
+    {
+        $or = $this->dm->getRepository($this->class);
+        if (!($or instanceof DocumentRepository)) {
+            throw new UnexpectedTypeException($this->dm, 'Doctrine\ODM\CouchDB\DocumentRepository');
+        }
+
+        return $or->findMany($values);
+    }
+}

--- a/Form/Type/DocumentType.php
+++ b/Form/Type/DocumentType.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\CouchDBBundle\Form\Type;
 
+use Doctrine\Bundle\CouchDBBundle\Form\ChoiceList\CouchDBEntityLoader;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Bridge\Doctrine\Form\Type\DoctrineType;
 use Symfony\Component\Form\Exception\FormException;
@@ -34,7 +35,10 @@ class DocumentType extends DoctrineType
      */
     public function getLoader(ObjectManager $manager, $queryBuilder, $class)
     {
-        throw new FormException('The query builder option is not supported by CouchDB.');
+        return new CouchDBEntityLoader(
+            $manager,
+            $class
+        );
     }
 
     public function getName()


### PR DESCRIPTION
In Symfony2.7 `couchdb_document` results in a `createQueryBuilder` method not found exception. So this is a basic implemention for an entity loader which needs some more "love".

to activate loader condition is nesseary to get into correct if condition inside `DoctrineType`:
```php
            ->add('foos', 'couchdb_document', array(
                'query_builder' => 'foo',
))
```

there some chances that we need a full querybuilder in future ...