### PR TITLE
fix proxy class generating for each request and class name comparing …

### DIFF
--- a/DoctrineCouchDBBundle.php
+++ b/DoctrineCouchDBBundle.php
@@ -57,10 +57,10 @@ class DoctrineCouchDBBundle extends Bundle
             $this->autoloader = function($class) use ($namespace, $dir, $container) {
                 if (0 === strpos($class, $namespace)) {
                     $className = substr($class, strlen($namespace) +1);
-                    $file = $dir.DIRECTORY_SEPARATOR.$className.'.php';
+                    $file = $dir.DIRECTORY_SEPARATOR . str_replace('\\', '', $className) . '.php';
 
                     if (!is_file($file) && $container->getParameter('doctrine_couchdb.odm.auto_generate_proxy_classes')) {
-                        $originalClassName = substr($className, 0, -5);
+                        $originalClassName = substr($className, 7);
                         $registry = $container->get('doctrine_couchdb');
 
                         // Tries to auto-generate the proxy file
@@ -70,9 +70,7 @@ class DoctrineCouchDBBundle extends Bundle
                                 $classes = $manager->getMetadataFactory()->getAllMetadata();
 
                                 foreach ($classes as $class) {
-                                    $name = str_replace('\\', '', $class->name);
-
-                                    if ($name == $originalClassName) {
+                                    if ($class->name == $originalClassName) {
                                         $manager->getProxyFactory()->generateProxyClasses(array($class));
                                     }
                                 }


### PR DESCRIPTION
Proxy generation fails because there are some issue on comparing class names: `FooBundlePageDocument` => `__CG__\Foo\Bundle\PageDoc`

```
The proxy file ...CouchDBProxies\/__CG__\\...PageDocument.php\u0022 does not exist. If you still have objects serialized in the session, you need to clear the session manually.","payload":["379d0c9febbb32b4db81469828275efe
```