### PR TITLE
remove deprecated factory service syntax.

### DIFF
--- a/DependencyInjection/DoctrineCouchDBExtension.php
+++ b/DependencyInjection/DoctrineCouchDBExtension.php
@@ -97,8 +97,7 @@ class DoctrineCouchDBExtension extends AbstractDoctrineExtension
 
         if (isset($connection['logging']) && $connection['logging'] === true) {
             $def = new Definition('Doctrine\CouchDB\HTTP\Client');
-            $def->setFactoryService(sprintf('doctrine_couchdb.client.%s_connection', $name));
-            $def->setFactoryMethod('getHttpClient');
+            $def->setFactory(array(new Reference(sprintf('doctrine_couchdb.client.%s_connection', $name)), 'getHttpClient'));
             $def->setPublic(false);
 
             $container->setDefinition(sprintf('doctrine_couchdb.httpclient.%s_client', $name), $def);

--- a/Resources/config/client.xml
+++ b/Resources/config/client.xml
@@ -19,10 +19,9 @@
 
         <service id="doctrine_couchdb.client.connection"
             class="%doctrine_couchdb.client.connection.class%"
-            factory-class="%doctrine_couchdb.client.connection.class%"
-            factory-method="create"
-            abstract="true"
-        />
+            abstract="true">
+            <factory class="%doctrine_couchdb.client.connection.class%" method="create" />
+        </service>
 
         <service id="doctrine_couchdb.datacollector" class="%doctrine_couchdb.datacollector.class%">
             <tag name="data_collector" template="DoctrineCouchDBBundle:Collector:couchdb" id="couchdb" />


### PR DESCRIPTION
Symfony 3 dropped the deprecated `setFactoryClass` and `setFactoryMethod` methods for definitions, and these have to be replaced with just `setFactory`. However, that method wasn't added until Symfony 2.5 (?), so this pull request breaks compatibility with this bundle's minimum requirements. Is there a way to support both variations in the XML service definitions?

In d13e6afffbbc33933dfb3296a6fab2e5225bb892, Symfony 3 support was added, but I don't see how it can actually work without this change. Should that patch be reverted?

What do the project maintainers advise?
