### PR TITLE
Fixed Symfony 3 issues and added timeout configuration option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -77,7 +77,8 @@ class Configuration implements ConfigurationInterface
                             'ip',
                             'logging',
                             'type',
-                            'url'
+                            'url',
+                            'timeout'
                         ) as $key) {
                             if (array_key_exists($key, $v)) {
                                 $connection[$key] = $v[$key];
@@ -119,6 +120,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('ssl')->defaultValue(false)->end()
                     ->booleanNode('logging')->defaultValue($this->debug)->end()
                     ->scalarNode('type')->end()
+                    ->scalarNode('timeout')->defaultValue(0.01)->end()
                 ->end()
             ->end()
         ;

--- a/DependencyInjection/DoctrineCouchDBExtension.php
+++ b/DependencyInjection/DoctrineCouchDBExtension.php
@@ -97,8 +97,7 @@ class DoctrineCouchDBExtension extends AbstractDoctrineExtension
 
         if (isset($connection['logging']) && $connection['logging'] === true) {
             $def = new Definition('Doctrine\CouchDB\HTTP\Client');
-            $def->setFactoryService(sprintf('doctrine_couchdb.client.%s_connection', $name));
-            $def->setFactoryMethod('getHttpClient');
+            $def->setFactory([new Reference(sprintf('doctrine_couchdb.client.%s_connection', $name)), 'getHttpClient']);
             $def->setPublic(false);
 
             $container->setDefinition(sprintf('doctrine_couchdb.httpclient.%s_client', $name), $def);

--- a/Resources/config/client.xml
+++ b/Resources/config/client.xml
@@ -17,12 +17,9 @@
 
     <services>
 
-        <service id="doctrine_couchdb.client.connection"
-            class="%doctrine_couchdb.client.connection.class%"
-            factory-class="%doctrine_couchdb.client.connection.class%"
-            factory-method="create"
-            abstract="true"
-        />
+        <service id="doctrine_couchdb.client.connection" class="%doctrine_couchdb.client.connection.class%">
+            <factory class="%doctrine_couchdb.client.connection.class%" method="create" />
+        </service>
 
         <service id="doctrine_couchdb.datacollector" class="%doctrine_couchdb.datacollector.class%">
             <tag name="data_collector" template="DoctrineCouchDBBundle:Collector:couchdb" id="couchdb" />


### PR DESCRIPTION
Hi,

I had issues using this bundle in our project, primarily 2 issues:

1) A couple of the service definitions were not working in our symfony project (v3.0.2).
2) The timeout value was hard coded and set really low (0.01s) which was causing every request to timeout because i was connecting to a remote couch db instance and not local. So i might it configurable (default is 0.01).

I'm guessing the symfony 3 fix will be incompatible with symfony 2 (I haven't checked if that is the case) so I'll leave it up to the project admins to determine how best to merge this. A v3.0 tag migh tbe the way to go.

Thanks
Asim
